### PR TITLE
Add CODEOWNERS file for code ownership management

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,39 @@
+# CODEOWNERS file for LOS-Modernization
+# This file defines code ownership and review requirements
+
+# Global owners - all files require review by @grndszn
+* @grndszn
+
+# Backend and server configuration files
+*.js @grndszn
+*.json @grndszn
+index.js @grndszn
+package.json @grndszn
+
+# Frontend and styling
+*.css @grndszn
+*.scss @grndszn
+*.ejs @grndszn
+public/ @grndszn
+static/ @grndszn
+
+# Documentation
+*.md @grndszn
+README.md @grndszn
+CLEANUP.md @grndszn
+
+# Security-sensitive files require extra scrutiny
+.github/ @grndszn
+.gitignore @grndszn
+LICENSE @grndszn
+
+# Configuration files
+.eslintrc.json @grndszn
+.prettierrc @grndszn
+nodemon.json @grndszn
+
+# Application directories
+app/ @grndszn
+content/ @grndszn
+processes/ @grndszn
+docs/ @grndszn


### PR DESCRIPTION
This PR adds a comprehensive CODEOWNERS file to establish code ownership and review requirements.

## Changes:
- Added .github/CODEOWNERS file with ownership rules for all repository components
- Defined @grndszn as the owner for all file types and directories
- Organized rules by category (backend, frontend, documentation, security-sensitive files, etc.)

## Benefits:
- Ensures code review requirements are automatically enforced
- Provides clear ownership structure for the repository
- Improves security by requiring review for all changes
- Supports the repository's modernization and security goals

## Validation:
The CODEOWNERS file syntax has been validated by GitHub and is confirmed as valid.